### PR TITLE
Tweak profile question data

### DIFF
--- a/lib/circuitdata/profile.rb
+++ b/lib/circuitdata/profile.rb
@@ -74,6 +74,7 @@ module Circuitdata
           schema: schema,
           path: json_pointer(path + [question_code])
         }
+        question[:uom] ||= schema[:uom]
       end
     end
 

--- a/lib/circuitdata/profile.rb
+++ b/lib/circuitdata/profile.rb
@@ -70,6 +70,13 @@ module Circuitdata
         end
         schema = descriptor.dup
         question[:description] = schema.delete(:description) || question[:description]
+
+        if question_type == :restricted && question[:defaults]
+          unless schema[:items][:type] == 'number'
+            schema[:items] = question[:defaults][:schema]
+          end
+        end
+
         question[question_type] = {
           schema: schema,
           path: json_pointer(path + [question_code])

--- a/test/test_data/reduced_profile_schema_with_restriction.json
+++ b/test/test_data/reduced_profile_schema_with_restriction.json
@@ -1,0 +1,72 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["open_trade_transfer_package"],
+  "properties": {
+    "open_trade_transfer_package": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "profiles": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "defaults": {
+              "type": "object",
+              "required": ["printed_circuits_fabrication_data"],
+              "properties": {
+                "printed_circuits_fabrication_data": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["version"],
+                  "properties": {
+                    "version": { "type": "string", "pattern": "^0.6$" },
+                    "rigid_conductive_layer": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "copper_foil_roughness": {
+                          "type": "string",
+                          "enum": ["S", "L", "V"],
+                          "uom": ["um"],
+                          "description": "The roughness of the copper foil."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "restricted": {
+              "type": "object",
+              "required": ["printed_circuits_fabrication_data"],
+              "properties": {
+                "printed_circuits_fabrication_data": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["version"],
+                  "properties": {
+                    "version": { "type": "string", "pattern": "^0.6$" },
+                    "rigid_conductive_layer": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "copper_foil_roughness": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "uniqueItems": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/test_profile.rb
+++ b/test/test_profile.rb
@@ -28,6 +28,7 @@ class CircuitdataProfileSchemaTest < Minitest::Test
             code: :copper_foil_roughness,
             name: 'Copper foil roughness',
             description: "The roughness of the copper foil.",
+            uom: ["um"],
             defaults: {
               schema: {
                 type: "string",

--- a/test/test_profile.rb
+++ b/test/test_profile.rb
@@ -17,6 +17,10 @@ class CircuitdataProfileSchemaTest < Minitest::Test
     read_json_test_file('reduced_profile_schema.json')
   end
 
+  def reduced_profile_schema_with_restriction
+    read_json_test_file('reduced_profile_schema_with_restriction.json')
+  end
+
   def test_profile_questions
     exp = [
       {
@@ -51,6 +55,49 @@ class CircuitdataProfileSchemaTest < Minitest::Test
     ]
 
     Circuitdata::Profile.stub(:schema, reduced_profile_schema) do
+      result = Circuitdata::Profile.questions
+      assert_same 1, result.length
+      assert_equal exp.first, result.first
+    end
+  end
+
+  def test_profile_questions_fix_missing_restriction_info
+    exp = [
+      {
+        id: :rigid_conductive_layer,
+        name: 'Rigid conductive layer',
+        questions: [
+          {
+            id: 'rigid_conductive_layer_copper_foil_roughness',
+            code: :copper_foil_roughness,
+            name: 'Copper foil roughness',
+            description: "The roughness of the copper foil.",
+            uom: ["um"],
+            defaults: {
+              schema: {
+                type: "string",
+                enum: ["S", "L", "V"],
+                uom: ["um"],
+              },
+              path: "/open_trade_transfer_package/profiles/defaults/printed_circuits_fabrication_data/rigid_conductive_layer/copper_foil_roughness"
+            },
+            restricted: {
+              schema: {
+                type: "array",
+                items: {
+                  type: "string",
+                  enum: ["S", "L", "V"],
+                  uom: ["um"],
+                }
+              },
+              path: "/open_trade_transfer_package/profiles/restricted/printed_circuits_fabrication_data/rigid_conductive_layer/copper_foil_roughness"
+            }
+          },
+        ]
+      }
+    ]
+
+    Circuitdata::Profile.stub(:schema, reduced_profile_schema_with_restriction) do
       result = Circuitdata::Profile.questions
       assert_same 1, result.length
       assert_equal exp.first, result.first


### PR DESCRIPTION
- Adds UoM data to root question node.
- Pulls restricted schema from defaults if present unless question is numeric.